### PR TITLE
DS-571: Set offset to smallest - Secor using new Group ID

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -80,7 +80,7 @@ kafka.consumer.timeout.ms=10000
 # Always use "smallest" unless you know what you're doing and are willing to risk
 # data loss for new topics or topics whose number of partitions has changed.
 # See the kafka docs for "auto.offset.reset".
-kafka.consumer.auto.offset.reset=largest
+kafka.consumer.auto.offset.reset=smallest
 
 # Choose between range and roundrobin partition assignment strategy for kafka
 # high level consumers. Check PartitionAssignor.scala in kafa 821 module for


### PR DESCRIPTION
DS-571: Set offset to smallest because Secor is now running under new Group ID https://github.com/hmhco/spark-pipeline/pull/434 and can start using smallest again